### PR TITLE
throw TypeError if fn.toString match returns null

### DIFF
--- a/multiline.js
+++ b/multiline.js
@@ -16,8 +16,11 @@
 		if (typeof fn !== 'function') {
 			throw new TypeError('Expected a function.');
 		}
-
-		return reCommentContents.exec(fn.toString())[1];
+		var match = reCommentContents.exec(fn.toString());
+		if(!match) {
+			throw new TypeError('Expected function to have a comment string.');
+		}
+		return match[1];
 	};
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
- this is a better error than: `Uncaught TypeError: Cannot read property '1' of null`
- this happened to me when my js was run through a minifier and comments were stripped out.  A better error would have made debugging easier
