### PR TITLE
Add string interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var stripIndent = require('strip-indent');
 // stop matching before: last newline => optional whitespace => comment end block
 var reCommentContents = /\/\*!?(?:\@preserve)?[ \t]*(?:\r\n|\n)([\s\S]*?)(?:\r\n|\n)\s*\*\//;
 
-var multiline = module.exports = function (fn) {
+var multiline = module.exports = function (fn, replaceObject) {
 	if (typeof fn !== 'function') {
 		throw new TypeError('Expected a function.');
 	}
@@ -16,9 +16,20 @@ var multiline = module.exports = function (fn) {
 		throw new TypeError('Multiline comment missing.');
 	}
 
+
+	// Uses Douglas Crockford's String supplant function to replace ${variableName} with the
+	// given variableName from the replaceObject.
+	if (Object.prototype.toString.call(replaceObject) === '[object Object]') {
+		match[1] = match[1].replace(/\$\{([^${}]*)\}/g,
+			function(a, b) {
+				var r = replaceObject[b];
+				return typeof r === 'string' || typeof r === 'number' ? r : a;
+			});
+	}
+
 	return match[1];
 };
 
-multiline.stripIndent = function (fn) {
-	return stripIndent(multiline(fn));
+multiline.stripIndent = function (fn, replaceObject) {
+	return stripIndent(multiline(fn, replaceObject));
 };


### PR DESCRIPTION
Unlike [#3](https://github.com/sindresorhus/multiline/pull/3) this requires the user to send in an object with the variables, and doesn't modify the behavior of the original function if no extra argument is passed. I guess it still might be a bit outside the project's scope, but if it's something that seems suitable I can add a few tests for it.

Example:

``` javascript
var testVar = 'Hi!';
var testString = multiline(function() {/*
Variable testVar is ${testVar}.
Another variable is ${other}.
*/}, {
  testVar: testVar,
  other: 'Something else.'
});
```
