### PR TITLE
fix: Preserve trailing newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var stripIndent = require('strip-indent');
 
 // start matching after: comment start block => ! or @preserve => optional whitespace => newline
 // stop matching before: last newline => optional whitespace => comment end block
-var reCommentContents = /\/\*!?(?:\@preserve)?[ \t]*(?:\r\n|\n)([\s\S]*?)(?:\r\n|\n)\s*\*\//;
+var reCommentContents = /\/\*!?(?:\@preserve)?[ \t]*(?:\r\n|\n)([\s\S]*?)(?:\r\n|\n)[ \t]*\*\//;
 
 var multiline = module.exports = function (fn) {
 	if (typeof fn !== 'function') {

--- a/test.js
+++ b/test.js
@@ -49,6 +49,16 @@ foo
 	assert.equal(actual, expected);
 });
 
+it('should preserve trailing empty lines', function () {
+	var actual = ml(function(){/*
+foo
+
+
+	*/});
+	var expected = 'foo\n\n';
+	assert.equal(actual, expected);
+});
+
 it('should throw if it can\'t match comment contents', function () {
 	assert.throws(function () {
 		ml(function(){});
@@ -85,6 +95,26 @@ describe('multiline.stripIndent()', function () {
 			</html>
 		*/});
 		var expected = '<!doctype html>\n<html>\n\n\t<body>\n\t\t<h1>Hello world!</h1>\n\t</body>\n</html>';
+		assert.equal(actual, expected);
+	});
+
+	it('should preserve leading empty lines', function () {
+		var actual = ml.stripIndent(function(){/*
+
+
+			foo
+		*/});
+		var expected = '\n\nfoo';
+		assert.equal(actual, expected);
+	});
+
+	it('should preserve trailing empty lines', function () {
+		var actual = ml.stripIndent(function(){/*
+			foo
+
+
+		*/});
+		var expected = 'foo\n\n';
 		assert.equal(actual, expected);
 	});
 });


### PR DESCRIPTION
I encountered this issue when creating Bower tests..